### PR TITLE
Fix: 로비로나가기, 로비 제목 길면 ...으로수정#40

### DIFF
--- a/components/GameRoom.tsx
+++ b/components/GameRoom.tsx
@@ -13,6 +13,7 @@ import { Crown, Play, CheckCircle, Circle, LogOut } from 'lucide-react';
 interface GameRoomProps {
   user: any;
   room: any;
+  onBack: () => void;
 }
 
 const GameRoom = ({ user, room }: GameRoomProps) => {


### PR DESCRIPTION
로비로 나가기 기능 구현
로비 제목이 일정 길이이상 길어지면 ...으로 나오게
알수없음이 뜨던거는 놀라운 토요일게임을 뺄수도있을것같아서 그냥 방만들기에서 제거